### PR TITLE
Fix Maven Central publication doc jar configuration

### DIFF
--- a/kmp-onboarding/build.gradle.kts
+++ b/kmp-onboarding/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     alias(libs.plugins.androidLint)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.dokka)
     alias(libs.plugins.mavenPublish)
 }
 
@@ -122,7 +121,7 @@ mavenPublishing {
 
     configure(
         KotlinMultiplatform(
-            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+            javadocJar = JavadocJar.Empty(),
             sourcesJar = true,
             androidVariantsToPublish = listOf("release")
         )


### PR DESCRIPTION
## Summary
- publish an empty documentation jar for the multiplatform artifacts so Sonatype validation accepts the uploaded klib targets
- remove the unused Dokka plugin from the library module configuration

## Testing
- not run (Android SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690672c7c02c8333a07203531a942b63